### PR TITLE
Add dev script to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "lerna run build",
     "precommit": "lint-staged",
+    "dev": "lerna run dev",
     "heroku-postbuild": "yarn run build",
     "postinstall": "lerna run postinstall",
     "lint": "eslint .",


### PR DESCRIPTION
In the `README`, it says you can use `yarn dev` to run the `dev` scripts of the backend and frontend but the script was missing.