### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,51 @@
 # Tom's Shuttle Service
 
 <div align="center">
-  <img alt="Tom's Shuttle Service" style="max-height:100px;""
-      src="./packages/frontend/src/images/logo.png"/>
+  <a href="#" rel="noopener" target="_blank">
+    <img alt="Tom's Shuttle Service" style="max-height:100px;"
+      src="./packages/frontend/src/images/logo.png"
+    />
+  </a>
 </div>
 
 <div align="center">
-  <a href="https://reactjs.org" rel="noopener" target="_blank">
-    <img alt="React" height="60" 
-      src="https://raw.githubusercontent.com/yarnpkg/assets/master/yarn-kitten-circle.png"/>
+  <a href="https://yarnpkg.com" rel="noopener" target="_blank">
+    <img alt="React" height="60"
+      src="https://raw.githubusercontent.com/yarnpkg/assets/master/yarn-kitten-circle.png"
+    />
   </a>
   <a href="https://reactjs.org" rel="noopener" target="_blank">
-    <img alt="React" height="60" 
-      src="https://avatars.githubusercontent.com/u/6412038"/>
+    <img alt="React" height="60"
+      src="https://avatars.githubusercontent.com/u/6412038"
+    />
   </a>
   <a href="https://material-ui.com/" rel="noopener" target="_blank">
-    <img height="60" width="60" src="https://material-ui.com/static/images/material-ui-logo.svg" alt="Material UI"/>
+    <img height="60" width="60"
+      src="https://material-ui.com/static/images/material-ui-logo.svg" alt="Material UI"
+    />
   </a>
   <a href="http://typeorm.io/" rel="noopener" target="_blank">
-    <img alt="TypeORM" height="60" src="https://raw.githubusercontent.com/typeorm/typeorm.github.io/master/image/logo/logo.png"/>
-  </a> 
+    <img alt="TypeORM" height="60"
+      src="https://raw.githubusercontent.com/typeorm/typeorm.github.io/master/image/logo/logo.png"
+    />
+  </a>
   <a href="https://expressjs.com" rel="noopener" target="_blank">
-    <img alt="Express" height="60" 
-      src="https://avatars.githubusercontent.com/u/5658226"/>
+    <img alt="Express" height="60"
+      src="https://avatars.githubusercontent.com/u/5658226"
+    />
   </a>
   <a href="https://developers.google.com/maps/" rel="noopener" target="_blank">
-    <img alt="Google Maps API" height="60" 
-      src="https://avatars.githubusercontent.com/u/3717923"/>
+    <img alt="Google Maps API" height="60"
+      src="https://avatars.githubusercontent.com/u/3717923"
+    />
   </a>
   <a href="https://webpack.js.org" rel="noopener" target="_blank">
-    <img alt="Webpack"  height="60" src="https://raw.githubusercontent.com/webpack/media/master/logo/icon.png"/>
-  </a> 
+    <img alt="Webpack"  height="60"
+      src="https://raw.githubusercontent.com/webpack/media/master/logo/icon.png"
+    />
+  </a>
   <a href="https://jestjs.io" rel="noopener" target="_blank">
-    <img height="60" src="https://jestjs.io/img/jest.png" alt="Jest"/>
+    <img alt="Jest" height="60" src="https://jestjs.io/img/jest.png" />
   </a>
 </div>
 
@@ -49,9 +62,7 @@
 [![Master Coverage Status](https://img.shields.io/codecov/c/github/vikr01/toms-shuttles/master.svg?label=coverage&logo=codecov)](https://codecov.io/gh/vikr01/toms-shuttles/branch/master)
 [![Dev Coverage Status](<https://img.shields.io/codecov/c/github/vikr01/toms-shuttles/dev.svg?label=coverage%20(dev)&logo=codecov>)](https://codecov.io/gh/vikr01/toms-shuttles/branch/dev)
 
-[![Dependency Status](https://img.shields.io/david/vikr01/toms-shuttles.svg?label=dependencies)](https://david-dm.org/vikr01/toms-shuttles)
 [![DevDependency Status](https://img.shields.io/david/dev/vikr01/toms-shuttles.svg?label=devDependencies)](https://david-dm.org/vikr01/toms-shuttles?type=dev)
-[![Known Vulnerabilities](https://snyk.io/test/github/vikr01/toms-shuttles/badge.svg?targetFile=package.json)](https://snyk.io/test/github/vikr01/toms-shuttles?targetFile=package.json)
 [![Renovate Enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://renovatebot.com/)
 
 </div>


### PR DESCRIPTION
- fix link to `yarn`
- there's no need for the badges `dependencies` and `vulnerabilities` in the root of the package since it's a monorepo and therefore shouldn't even have dependencies